### PR TITLE
Add custom user agent parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 ## This node is still Work in Progress and mainly for testing purposes
 
 Load image from URL and downscale to desired megapixels. Set megapixels to 0 for no downscaling.
+
+##
+
+Test image needs to start with HTTP/HTTPS and end with allowed package extensions. 
+If you don´t know how to use try this:
+Find photo that you like from browser, go to that site and on right click on image and choose Open image in new tab, then you get right type of url to use on this custom node.

--- a/kimara_ai_image_from_url.py
+++ b/kimara_ai_image_from_url.py
@@ -17,8 +17,7 @@ class KimaraAIImageFromURL:
             "required": {
                 "url": ("STRING", {"multiline": False, "default": "", "lazy": False}),
                 "megapixels": ("FLOAT", {"default": 1, "min": 0, "max": 20, "step": 0.1}),
-                }, "optional": {
-                    "user_agent": ("STRING", {"multiline": False, "default": "ComfyUI Image Downloader/1.0", "lazy": False})
+                "user_agent": ("STRING", {"multiline": False, "default": "ComfyUI Image Downloader/1.0", "lazy": False})
             }
         }
         
@@ -39,7 +38,9 @@ class KimaraAIImageFromURL:
             image_tensor, mask_tensor = self.process_image(img, megapixels)
         except urllib.error.HTTPError as e:
             if e.code == 403:
-                raise ValueError("403 Forbidden: Access is denied")
+                raise ValueError("403 Forbidden:{url} has blocked this request. Try changing the User_Agent.")
+            elif e.code == 404:
+                raise ValueError("404 Not found: The images url is incorrect or no longer available.")
             else:
                 raise ValueError(f"Error loading image from '{url}': {e}")
         except (urllib.error.URLError, IOError) as e:


### PR DESCRIPTION
Acceptance Criteria

Add a "user_agent" string parameter to the node's inputs

Set a sensible default user agent string

Update the URL request to include the custom user agent in the headers

Provide user-friendly error messages for HTTP 403 (Forbidden) responses

Test against common sites that require user agents

I tried to make it an "advanced" parameter that's collapsed by default, but adding optional alongside with required didn't do nothing special and adding advanced, hid it and then there was no option to change the user_agent.